### PR TITLE
changelog: fix link to GitHub releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0](https://github.com/dbmdz/mirador-imagecropper/releases/tag/0.2.0) - 2022-03-25
+## [0.2.0](https://github.com/dbmdz/mirador-canvaslink/releases/tag/0.2.0) - 2022-03-25
 
 ### Added
 
 - Added sharing of configurable canvaslink
 
-## [0.1.0](https://github.com/dbmdz/mirador-imagecropper/releases/tag/0.1.0) - 2022-03-11
+## [0.1.0](https://github.com/dbmdz/mirador-canvaslink/releases/tag/0.1.0) - 2022-03-11
 
 This was the initial version.


### PR DESCRIPTION
Hi,

this PR fixes the link in changelog to the correct GitHub releases in this repo.