### PR TITLE
Fix fullscreen dialog

### DIFF
--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -22,6 +22,7 @@ const config = {
   ],
   id: "demo",
   window: {
+    allowFullscreen: true,
     canvasLink: {
       active: true,
       enabled: true,

--- a/src/components/ShareButton.js
+++ b/src/components/ShareButton.js
@@ -28,9 +28,9 @@ const ShareButton = ({
   const link = getShareLink(
     attribution,
     canvasLink,
-    label,
     provider,
-    thumbnailUrl
+    thumbnailUrl,
+    label
   );
   const ProviderIcon = iconMapping[provider];
   return (

--- a/src/components/ShareCanvasLinkDialog.js
+++ b/src/components/ShareCanvasLinkDialog.js
@@ -32,6 +32,7 @@ const useStyles = makeStyles((theme) => ({
 const supportsClipboard = "clipboard" in navigator;
 
 const ShareCanvasLinkDialog = ({
+  containerId,
   manifestId,
   visibleCanvases,
   label,
@@ -39,6 +40,7 @@ const ShareCanvasLinkDialog = ({
   rights,
   t,
   updateOptions,
+  windowId,
 }) => {
   const { dialogOpen, enabled, showRightsInformation, getCanvasLink } = options;
   const [copiedToClipboard, setCopiedToClipboard] = useState(false);
@@ -58,6 +60,7 @@ const ShareCanvasLinkDialog = ({
 
   return (
     <Dialog
+      container={document.querySelector(`#${containerId} #${windowId}`)}
       fullWidth
       maxWidth="sm"
       scroll="paper"
@@ -126,6 +129,7 @@ const ShareCanvasLinkDialog = ({
 };
 
 ShareCanvasLinkDialog.propTypes = {
+  containerId: PropTypes.string.isRequired,
   manifestId: PropTypes.string.isRequired,
   visibleCanvases: PropTypes.arrayOf(
     PropTypes.shape({
@@ -143,6 +147,7 @@ ShareCanvasLinkDialog.propTypes = {
   rights: PropTypes.arrayOf(PropTypes.string),
   t: PropTypes.func.isRequired,
   updateOptions: PropTypes.func.isRequired,
+  windowId: PropTypes.string.isRequired,
 };
 
 ShareCanvasLinkDialog.defaultProps = {

--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -1,9 +1,9 @@
 export function getShareLink(
   attribution,
   imageUrl,
-  label = "",
   provider,
-  thumbnailUrl
+  thumbnailUrl,
+  label = ""
 ) {
   let text = label;
   if (attribution) {


### PR DESCRIPTION
This PR adds the missing `container` prop to the dialog component to make it visible in fullscreen mode.